### PR TITLE
Moving the Cursor to already existing prefill value

### DIFF
--- a/internal/ui/var_resolve.go
+++ b/internal/ui/var_resolve.go
@@ -317,6 +317,16 @@ func (m *mainModel) handleShellResult(msg shellResultMsg) (tea.Model, tea.Cmd) {
 			m.textInput.CursorEnd()
 		}
 		m.varState.picker.Filter(m.textInput.Value())
+
+		// Set the cursor location, if the variable already exists in prefilled.
+		if vs.prefill != "" {
+			for i, opt := range m.varState.picker.Filtered {
+				if opt.Original == vs.prefill {
+					m.varState.picker.Cursor = i
+					break
+				}
+			}
+		}
 	}
 
 	return m, nil

--- a/internal/ui/var_resolve_test.go
+++ b/internal/ui/var_resolve_test.go
@@ -69,3 +69,95 @@ func TestVarResolvePrefillFiltersSelectionOptions(t *testing.T) {
 		t.Fatalf("filtered option = %q", got.varState.picker.Filtered[0].Display)
 	}
 }
+
+func TestVarResolveHandleShellResultPrefillMovesCursor(t *testing.T) {
+	options := []string{"alpha", "beta", "gamma", "test.testing.test", "testing.test"}
+
+	tests := []struct {
+		name         string
+		prefill      string
+		wantCursor   int
+		wantInput    string
+		wantFiltered int
+	}{
+		{
+			// "beta" filters the list to ["beta"]; exact match sits at Filtered[0].
+			name:         "prefill matching second option lands at filtered index 0",
+			prefill:      "beta",
+			wantCursor:   0,
+			wantInput:    "beta",
+			wantFiltered: 1,
+		},
+		{
+			// "alpha" filters to ["alpha"]; exact match at Filtered[0].
+			name:         "prefill matching first option lands at filtered index 0",
+			prefill:      "alpha",
+			wantCursor:   0,
+			wantInput:    "alpha",
+			wantFiltered: 1,
+		},
+		{
+			// "gamma" filters to ["gamma"]; exact match at Filtered[0].
+			name:         "prefill matching last option lands at filtered index 0",
+			prefill:      "gamma",
+			wantCursor:   0,
+			wantInput:    "gamma",
+			wantFiltered: 1,
+		},
+		{
+			// No prefill: Filter("") keeps all items, cursor stays at 0.
+			name:         "no prefill leaves cursor at zero with all options visible",
+			prefill:      "",
+			wantCursor:   0,
+			wantInput:    "",
+			wantFiltered: 5,
+		},
+		{
+			// "delta" matches nothing; Filtered is empty, cursor clamped to 0.
+			name:         "prefill with no match leaves empty filtered list cursor at zero",
+			prefill:      "delta",
+			wantCursor:   0,
+			wantInput:    "delta",
+			wantFiltered: 0,
+		},
+		{
+			// "testing.test" filters the list to ["test.testing.test", "testing.test"]; exact match sits at Filtered[1].
+			name:         "prefill matching substring ",
+			prefill:      "testing.test",
+			wantCursor:   1,
+			wantInput:    "testing.test",
+			wantFiltered: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newMainModel([]*parser.Cheat{{Header: "One"}}, parser.NewCheatIndex(), nil)
+			m.phase = phaseVarResolve
+			m.varState = &varResolveState{
+				vars: []varState{
+					{
+						def:     parser.VarDef{Name: "TARGET"},
+						prefill: tt.prefill,
+					},
+				},
+			}
+
+			model, _ := m.handleShellResult(shellResultMsg{options: options})
+			got := model.(*mainModel)
+
+			if got.varState.picker == nil {
+				t.Fatal("picker is nil")
+			}
+			if len(got.varState.picker.Filtered) != tt.wantFiltered {
+				t.Fatalf("len(Filtered) = %d, want %d", len(got.varState.picker.Filtered), tt.wantFiltered)
+			}
+			if got.varState.picker.Cursor != tt.wantCursor {
+				t.Fatalf("cursor = %d, want %d", got.varState.picker.Cursor, tt.wantCursor)
+			}
+			if got.textInput.Value() != tt.wantInput {
+				t.Fatalf("input = %q, want %q", got.textInput.Value(), tt.wantInput)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently the Cursor will always be at the topmost entry of the values. If there is already a prefill value, the cursor will not select the fitting entry.

This change will move the cursor to the fitting entry and add tests for this.