### PR TITLE
fix(headless): replace bufio.Scanner with json.Decoder for unbounded RPC payload size

### DIFF
--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -1,7 +1,6 @@
 package headless
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -40,7 +39,7 @@ type RunnerSession struct {
 	Exec    Executor
 	Cheat   *parser.Cheat
 	Vars    []resolver.VarState
-	Scanner *bufio.Scanner
+	Decoder *json.Decoder
 }
 
 // Run acts as the primary entry point, constructing a session and starting the execution.
@@ -48,7 +47,7 @@ func Run(index *parser.CheatIndex, exec Executor, initialQuery, matchCmd string)
 	session := &RunnerSession{
 		Index:   index,
 		Exec:    exec,
-		Scanner: bufio.NewScanner(os.Stdin),
+		Decoder: json.NewDecoder(os.Stdin),
 	}
 	return session.Execute(initialQuery, matchCmd)
 }

--- a/internal/headless/headless_test.go
+++ b/internal/headless/headless_test.go
@@ -249,3 +249,71 @@ func TestRunHeadlessConditionalDependencies(t *testing.T) {
 		t.Errorf("unexpected command: %q", completed.Params.Command)
 	}
 }
+
+func TestRunHeadlessRPCLimit(t *testing.T) {
+	cheat := &parser.Cheat{
+		File:    "test.md",
+		Header:  "Test Headless Limit",
+		Command: "echo $payload",
+		Vars: []parser.VarDef{
+			{Name: "payload"},
+		},
+	}
+
+	index := parser.NewCheatIndex()
+	index.Cheats = []*parser.Cheat{cheat}
+
+	oldStdin := os.Stdin
+	oldStdout := os.Stdout
+	defer func() {
+		os.Stdin = oldStdin
+		os.Stdout = oldStdout
+	}()
+
+	rIn, wIn, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdin = rIn
+
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = wOut
+
+	largePayload := strings.Repeat("a", 70000)
+
+	resBytes, _ := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"result": map[string]interface{}{
+			"values": map[string]string{
+				"payload": largePayload,
+			},
+		},
+		"id": 1,
+	})
+	go func() {
+		_, _ = wIn.Write(append(resBytes, '\n'))
+		_ = wIn.Close()
+	}()
+
+	exec := &mockHeadlessExecutor{
+		finalCmd: "echo " + largePayload,
+	}
+
+	outChan := make(chan string)
+	go func() {
+		var buf strings.Builder
+		_, _ = io.Copy(&buf, rOut)
+		outChan <- buf.String()
+	}()
+
+	err = Run(index, exec, "Test Headless Limit", "")
+	_ = wOut.Close()
+
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+	<-outChan
+}

--- a/internal/headless/vars.go
+++ b/internal/headless/vars.go
@@ -309,16 +309,16 @@ func (s *RunnerSession) promptClient(promptVars []promptVar) error {
 
 	fmt.Println(string(reqBytes))
 
-	if !s.Scanner.Scan() {
-		return fmt.Errorf("client connection severed unexpectedly during variable prompt")
+	var promptRes promptResponse
+	if err := s.Decoder.Decode(&promptRes); err != nil {
+		return fmt.Errorf("client connection severed unexpectedly or invalid JSON: %w", err)
 	}
 
-	promptRes, err := s.parsePromptResponse(s.Scanner.Text())
-	if err != nil {
-		return err
+	if promptRes.Error != nil {
+		return fmt.Errorf("client aborted prompt: %s", promptRes.Error.Message)
 	}
 
-	s.ingestPromptValues(promptVars, promptRes)
+	s.ingestPromptValues(promptVars, &promptRes)
 	return nil
 }
 
@@ -349,19 +349,6 @@ type promptResponse struct {
 		Message string `json:"message"`
 	} `json:"error"`
 	Id int `json:"id"`
-}
-
-func (s *RunnerSession) parsePromptResponse(line string) (*promptResponse, error) {
-	var promptRes promptResponse
-	if err := json.Unmarshal([]byte(line), &promptRes); err != nil {
-		return nil, fmt.Errorf("failed to parse client prompt response: %w", err)
-	}
-
-	if promptRes.Error != nil {
-		return nil, fmt.Errorf("client aborted prompt: %s", promptRes.Error.Message)
-	}
-
-	return &promptRes, nil
 }
 
 func (s *RunnerSession) ingestPromptValues(promptVars []promptVar, promptRes *promptResponse) {


### PR DESCRIPTION
## Summary

This PR changes how `headless.RunnerSession` consumes JSON-RPC responses from `os.Stdin`. Previously, it used `bufio.Scanner` to read responses line-by-line, which is subject to a hardcoded 64KB token limit. This would cause the JSON-RPC connection to sever if the client responded with a payload larger than 64KB. This PR replaces `bufio.Scanner` with `json.Decoder` allowing unbounded JSON object streams and fixing the 64KB token crash.