### PR TITLE
fix(headless): add idle timeout for executing interactive commands

### DIFF
--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -5,16 +5,22 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/cheatmd-dev/cheatmd/internal/resolver"
 	"github.com/cheatmd-dev/cheatmd/pkg/config"
 	"github.com/cheatmd-dev/cheatmd/pkg/executor"
 	"github.com/cheatmd-dev/cheatmd/pkg/parser"
 )
+
+// IdleTimeout defines the maximum duration a command can run without producing output
+// before being forcefully killed.
+var IdleTimeout = 5 * time.Minute
 
 // Executor defines the interface required by the headless runner for shell command execution.
 type Executor interface {
@@ -209,16 +215,43 @@ func (s *RunnerSession) determineRunStatus(err error) (string, string) {
 // Helper Utilities
 // -----------------------------------------------------------------------------
 
+// trackingWriter resets a timer upon every write operation.
+type trackingWriter struct {
+	w       io.Writer
+	onWrite func()
+}
+
+func (t *trackingWriter) Write(p []byte) (n int, err error) {
+	t.onWrite()
+	return t.w.Write(p)
+}
+
 // runCommandAndCapture shells out the given command and intercepts both standard streams.
+// It kills the process if it produces no output for IdleTimeout.
 func runCommandAndCapture(shell, command string) (string, string, error) {
 	cmd := exec.Command(shell, "-c", command)
 	cmd.Env = os.Environ()
 
 	var stdoutBuf, stderrBuf bytes.Buffer
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
 
-	err := cmd.Run()
+	timer := time.AfterFunc(IdleTimeout, func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+	defer timer.Stop()
+
+	resetTimer := func() {
+		timer.Reset(IdleTimeout)
+	}
+
+	cmd.Stdout = &trackingWriter{w: &stdoutBuf, onWrite: resetTimer}
+	cmd.Stderr = &trackingWriter{w: &stderrBuf, onWrite: resetTimer}
+
+	if err := cmd.Start(); err != nil {
+		return "", "", err
+	}
+	err := cmd.Wait()
 	return stdoutBuf.String(), stderrBuf.String(), err
 }
 

--- a/internal/headless/headless_test.go
+++ b/internal/headless/headless_test.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/cheatmd-dev/cheatmd/pkg/config"
 	"github.com/cheatmd-dev/cheatmd/pkg/executor"
 	"github.com/cheatmd-dev/cheatmd/pkg/parser"
 )
@@ -247,5 +249,58 @@ func TestRunHeadlessConditionalDependencies(t *testing.T) {
 	}
 	if completed.Params.Command != "curl https://api.example.com/api -u admin -p secret123" {
 		t.Errorf("unexpected command: %q", completed.Params.Command)
+	}
+}
+
+func TestRunHeadlessIdleTimeout(t *testing.T) {
+	oldTimeout := IdleTimeout
+	IdleTimeout = 100 * time.Millisecond
+	defer func() { IdleTimeout = oldTimeout }()
+
+	cheat := &parser.Cheat{
+		File:    "test.md",
+		Header:  "Test Timeout",
+		Command: "sleep 2",
+	}
+
+	index := parser.NewCheatIndex()
+	index.Cheats = []*parser.Cheat{cheat}
+
+	oldStdout := os.Stdout
+	defer func() {
+		os.Stdout = oldStdout
+		config.Get().Output = "print"
+	}()
+	config.Get().Output = "exec"
+	config.Get().Shell = "bash"
+	rOut, wOut, _ := os.Pipe()
+	os.Stdout = wOut
+
+	exec := &mockHeadlessExecutor{
+		finalCmd: "sleep 2",
+	}
+
+	outChan := make(chan string)
+	go func() {
+		var buf strings.Builder
+		_, _ = io.Copy(&buf, rOut)
+		outChan <- buf.String()
+	}()
+
+	err := Run(index, exec, "Test Timeout", "")
+	_ = wOut.Close()
+
+	if err == nil {
+		t.Errorf("expected timeout error, got nil")
+	}
+
+	capturedStdout := <-outChan
+	lines := strings.Split(strings.TrimSpace(capturedStdout), "\n")
+	if len(lines) == 0 {
+		t.Fatalf("no output")
+	}
+	lastLine := lines[len(lines)-1]
+	if !strings.Contains(lastLine, "killed") && !strings.Contains(lastLine, "error") {
+		t.Errorf("expected killed error in output, got %s", lastLine)
 	}
 }


### PR DESCRIPTION
## Summary

This PR addresses a bug where executing interactive shell commands (like `read`, `sudo`, `vim`) in headless mode would cause the process to hang forever because `cmd.Stdin` is disconnected from the TTY. To prevent these hangs without interfering with legitimate long-running background tasks, this PR introduces a 5-minute idle output timeout. If the executed process produces no standard output or standard error for 5 minutes, it is forcibly killed.
