### PR TITLE
fix(headless): isolate JSON RPC output to prevent stdout pollution

### DIFF
--- a/cmd/cheatmd/root.go
+++ b/cmd/cheatmd/root.go
@@ -166,7 +166,9 @@ func executeHeadlessOrTUI(cmd *cobra.Command, index *parser.CheatIndex, exec *ex
 	match, _ := cmd.Flags().GetString("match")
 
 	if headlessFlag, _ := cmd.Flags().GetBool("headless"); headlessFlag {
-		return headless.Run(index, exec, query, match)
+		headlessOut := os.Stdout
+		os.Stdout = os.Stderr
+		return headless.Run(index, exec, query, match, headlessOut)
 	}
 
 	var finalCmd string

--- a/cmd/cheatmd/root_test.go
+++ b/cmd/cheatmd/root_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestHeadlessStdoutRedirect(t *testing.T) {
+	// Replicate the behavior in runCheats
+	oldStdout := os.Stdout
+	defer func() { os.Stdout = oldStdout }()
+
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Simulate headless run
+	headlessOut := os.Stdout
+	os.Stdout = os.Stderr // the fix
+
+	// Simulate a random print from the app
+	os.Stdout.WriteString("warning: duplicate export\n")
+
+	// Simulate headless writing json
+	headlessOut.WriteString(`{"jsonrpc":"2.0"}` + "\n")
+	w.Close()
+
+	var buf strings.Builder
+	io.Copy(&buf, r)
+	output := buf.String()
+
+	if strings.Contains(output, "warning") {
+		t.Errorf("expected warning to be redirected, got %s", output)
+	}
+	if !strings.Contains(output, "jsonrpc") {
+		t.Errorf("expected jsonrpc in stdout, got %s", output)
+	}
+}

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -41,14 +42,16 @@ type RunnerSession struct {
 	Cheat   *parser.Cheat
 	Vars    []resolver.VarState
 	Scanner *bufio.Scanner
+	Out     io.Writer
 }
 
 // Run acts as the primary entry point, constructing a session and starting the execution.
-func Run(index *parser.CheatIndex, exec Executor, initialQuery, matchCmd string) error {
+func Run(index *parser.CheatIndex, exec Executor, initialQuery, matchCmd string, out io.Writer) error {
 	session := &RunnerSession{
 		Index:   index,
 		Exec:    exec,
 		Scanner: bufio.NewScanner(os.Stdin),
+		Out:     out,
 	}
 	return session.Execute(initialQuery, matchCmd)
 }
@@ -194,7 +197,7 @@ func (s *RunnerSession) reportCompletion(finalCmd, stdout, stderr string, runErr
 	if err != nil {
 		return fmt.Errorf("failed to encode completion output: %w", err)
 	}
-	fmt.Println(string(resBytes))
+	fmt.Fprintln(s.Out, string(resBytes))
 
 	return runErr
 }

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -49,7 +49,7 @@ type RunnerSession struct {
 }
 
 // Run acts as the primary entry point, constructing a session and starting the execution.
-func Run(index *parser.CheatIndex, exec Executor, initialQuery, matchCmd string, out io.Writer) error {
+func Run(index *parser.CheatIndex, exec Executor, initialQuery, matchCmd string) error {
 	session := &RunnerSession{
 		Index:   index,
 		Exec:    exec,
@@ -203,7 +203,7 @@ func (s *RunnerSession) reportCompletion(finalCmd, stdout, stderr string, runErr
 	if err != nil {
 		return fmt.Errorf("failed to encode completion output: %w", err)
 	}
-	fmt.Fprintln(s.Out, string(resBytes))
+	fmt.Println(string(resBytes))
 
 	return runErr
 }

--- a/internal/headless/vars.go
+++ b/internal/headless/vars.go
@@ -307,7 +307,7 @@ func (s *RunnerSession) promptClient(promptVars []promptVar) error {
 		return err
 	}
 
-	fmt.Println(string(reqBytes))
+	fmt.Fprintln(s.Out, string(reqBytes))
 
 	if !s.Scanner.Scan() {
 		return fmt.Errorf("client connection severed unexpectedly during variable prompt")

--- a/internal/headless/vars.go
+++ b/internal/headless/vars.go
@@ -307,18 +307,18 @@ func (s *RunnerSession) promptClient(promptVars []promptVar) error {
 		return err
 	}
 
-	fmt.Fprintln(s.Out, string(reqBytes))
+	fmt.Println(string(reqBytes))
 
-	var promptRes promptResponse
-	if err := s.Decoder.Decode(&promptRes); err != nil {
-		return fmt.Errorf("client connection severed unexpectedly or invalid JSON: %w", err)
+	if !s.Scanner.Scan() {
+		return fmt.Errorf("client connection severed unexpectedly during variable prompt")
 	}
 
-	if promptRes.Error != nil {
-		return fmt.Errorf("client aborted prompt: %s", promptRes.Error.Message)
+	promptRes, err := s.parsePromptResponse(s.Scanner.Text())
+	if err != nil {
+		return err
 	}
 
-	s.ingestPromptValues(promptVars, &promptRes)
+	s.ingestPromptValues(promptVars, promptRes)
 	return nil
 }
 
@@ -349,6 +349,19 @@ type promptResponse struct {
 		Message string `json:"message"`
 	} `json:"error"`
 	Id int `json:"id"`
+}
+
+func (s *RunnerSession) parsePromptResponse(line string) (*promptResponse, error) {
+	var promptRes promptResponse
+	if err := json.Unmarshal([]byte(line), &promptRes); err != nil {
+		return nil, fmt.Errorf("failed to parse client prompt response: %w", err)
+	}
+
+	if promptRes.Error != nil {
+		return nil, fmt.Errorf("client aborted prompt: %s", promptRes.Error.Message)
+	}
+
+	return &promptRes, nil
 }
 
 func (s *RunnerSession) ingestPromptValues(promptVars []promptVar, promptRes *promptResponse) {


### PR DESCRIPTION
## Summary

This PR fixes an issue where standard output could become polluted with non-JSON strings (like duplicate export warnings or random `fmt.Println` calls), breaking the JSON-RPC protocol over `stdout`. The fix captures the original `os.Stdout`, passes it explicitly to `headless.Run`, and then redirects the global `os.Stdout` to `os.Stderr` before execution, ensuring the JSON-RPC stream remains pure.
