### PR TITLE
fix(parser): correct misleading ANSI warning message

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -512,7 +512,7 @@ func (p *Parser) createCheat(path string, s *parseState, block codeBlock, cheatB
 		p.index.Errors = append(p.index.Errors, ParseError{
 			File:    path,
 			Line:    cheatLine,
-			Message: "cheat contains raw ANSI escape sequences which will be sanitized",
+			Message: "cheat contains raw ANSI escape sequences which may cause parsing errors. Please remove them manually.",
 		})
 	}
 

--- a/pkg/parser/parser_ansi_test.go
+++ b/pkg/parser/parser_ansi_test.go
@@ -1,0 +1,25 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestANSIWarningMessage(t *testing.T) {
+	p := NewParser()
+	content := []byte("# \x1b[31mCheat\x1b[0m\n```bash\necho 1\n```\n")
+
+	p.parseLines("test.md", content)
+
+	// Create cheats so createCheat runs
+	_ = p.index.Cheats
+
+	if len(p.index.Errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(p.index.Errors))
+	}
+
+	errMessage := p.index.Errors[0].Message
+	if !strings.Contains(errMessage, "Please remove them manually") {
+		t.Errorf("expected warning to mention manual removal, got %q", errMessage)
+	}
+}


### PR DESCRIPTION
## Summary
This PR updates a misleading warning message emitted by the parser when it encounters ANSI escape codes in cheat blocks. The parser was warning users that the codes "have been removed" or "will be sanitized", but the parser doesn't actually strip them. The message now accurately warns that ANSI codes may cause parsing issues and asks the user to remove them manually.
