### PR TITLE
fix(parser): correct line numbers for multiline DSL expressions

### DIFF
--- a/pkg/parser/dsl.go
+++ b/pkg/parser/dsl.go
@@ -12,16 +12,16 @@ import (
 // avoids per-line regex matching. Each non-comment, non-blank line is matched
 // against at most one branch.
 func parseCheatDSL(cheat *Cheat, content string, path string, startLine int) []ParseError {
-	lines := joinContinuationLines(strings.Split(content, "\n"))
+	lines := joinContinuationLines(strings.Split(content, "\n"), startLine)
 
 	var currentCondition string
 	var errs []ParseError
 	ifDepth := 0
 	ifLines := []int{}
 
-	for i, line := range lines {
-		lineNo := startLine + i
-		line = strings.TrimSpace(line)
+	for _, ll := range lines {
+		lineNo := ll.lineNo
+		line := strings.TrimSpace(ll.text)
 		if line == "" || line[0] == '#' {
 			continue
 		}
@@ -192,24 +192,36 @@ func containsWhitespace(s string) bool {
 	return false
 }
 
-// joinContinuationLines joins lines that end with backslash.
-func joinContinuationLines(lines []string) []string {
-	var result []string
-	var current strings.Builder
+type logicalLine struct {
+	text   string
+	lineNo int
+}
 
-	for _, line := range lines {
+// joinContinuationLines joins lines that end with backslash and maps back to original line numbers.
+func joinContinuationLines(lines []string, startLine int) []logicalLine {
+	var result []logicalLine
+	var current strings.Builder
+	var startLineNo int
+	isContinuation := false
+
+	for i, line := range lines {
+		if !isContinuation {
+			startLineNo = startLine + i
+		}
 		trimmed := strings.TrimRight(line, " \t")
 		if strings.HasSuffix(trimmed, "\\") {
 			current.WriteString(strings.TrimSuffix(trimmed, "\\"))
+			isContinuation = true
 		} else {
 			current.WriteString(line)
-			result = append(result, current.String())
+			result = append(result, logicalLine{text: current.String(), lineNo: startLineNo})
 			current.Reset()
+			isContinuation = false
 		}
 	}
 
 	if current.Len() > 0 {
-		result = append(result, current.String())
+		result = append(result, logicalLine{text: current.String(), lineNo: startLineNo})
 	}
 
 	return result

--- a/pkg/parser/dsl_test.go
+++ b/pkg/parser/dsl_test.go
@@ -1,0 +1,53 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestDSLIfNesting(t *testing.T) {
+	cheat := &Cheat{}
+	dslBlock := `
+if A
+	if B
+		var X = echo x
+	fi
+	var Y = echo y
+fi
+`
+	errs := parseCheatDSL(cheat, dslBlock, "test.md", 1)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	if len(cheat.Vars) != 2 {
+		t.Fatalf("expected 2 vars, got %d", len(cheat.Vars))
+	}
+
+	for _, v := range cheat.Vars {
+		if v.Name == "X" && v.Condition != "B" {
+			t.Errorf("expected var X condition to be B, got %s", v.Condition)
+		}
+		if v.Name == "Y" && v.Condition != "A" {
+			t.Errorf("expected var Y condition to be A, got %s", v.Condition)
+		}
+	}
+}
+
+func TestDSLLineNumberContinuations(t *testing.T) {
+	cheat := &Cheat{}
+	dslBlock := `
+var X = \
+	echo x
+
+invalid_keyword
+`
+	errs := parseCheatDSL(cheat, dslBlock, "test.md", 10)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errs))
+	}
+
+	// invalid_keyword is on line 5 of the block, starting at 10 -> line 14
+	if errs[0].Line != 14 {
+		t.Errorf("expected error on line 14, got line %d", errs[0].Line)
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes an issue where line numbers reported in DSL parse errors became desynchronized from the source file. When `joinContinuationLines` merged multiline commands ending in a backslash (`\`), it reduced the total line count, causing subsequent errors to report the wrong line number. This fix introduces a `logicalLine` struct to track the original starting line number for each merged block.