### PR TITLE
fix(parser): prevent parallel parser from dropping errors

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -99,6 +99,7 @@ func parseFilesParallel(files []string) []parseResult {
 			localCheats := make([]*Cheat, 0, estimatedCheats/numWorkers)
 			localModules := make(map[string]*Module)
 			var localDuplicates []DuplicateExport
+			var localErrors []ParseError
 
 			for _, path := range fileChunk {
 				if info, err := os.Stat(path); err == nil && info.Size() <= 5*1024*1024 {
@@ -107,10 +108,11 @@ func parseFilesParallel(files []string) []parseResult {
 						localParser.parseLines(path, data)
 						localCheats = append(localCheats, localParser.index.Cheats...)
 						localModules = mergeModules(localModules, &localDuplicates, localParser.index.Modules)
+						localErrors = append(localErrors, localParser.index.Errors...)
 					}
 				}
 			}
-			resultChan <- parseResult{cheats: localCheats, modules: localModules, duplicates: localDuplicates, errors: localParser.index.Errors}
+			resultChan <- parseResult{cheats: localCheats, modules: localModules, duplicates: localDuplicates, errors: localErrors}
 		}(chunk)
 	}
 

--- a/pkg/parser/parser_parallel_test.go
+++ b/pkg/parser/parser_parallel_test.go
@@ -1,0 +1,29 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseDirectoryParallelErrors(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "test_cheats_err")
+	os.MkdirAll(dir, 0755)
+
+	// Create 100 files with parse errors
+	for i := 0; i < 100; i++ {
+		content := fmt.Sprintf("# Cheat %d\n```bash\necho %d\n```\n<!-- cheat\nvar x = \n-->\n", i, i)
+		err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("file_%d.md", i)), []byte(content), 0644)
+		if err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+	}
+
+	p := NewParser()
+	index, _ := p.ParseDirectory(dir)
+
+	if len(index.Errors) != 100 {
+		t.Errorf("expected 100 errors, got %d", len(index.Errors))
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes a bug in `ParseDirectory`'s parallel worker pool where parse errors from early files in a worker's chunk were silently overwritten by the results of later files. The worker loop was resetting the `localParser.index` on every iteration, causing it to only report errors from the very last file it processed. This fix correctly aggregates `ParseError` objects across the entire chunk.